### PR TITLE
Remove test scope and use property enrichment

### DIFF
--- a/src/KiBoards.Extensions.Logging.Tests/DiagnosticLoggerFixture_TestCase_Must.cs
+++ b/src/KiBoards.Extensions.Logging.Tests/DiagnosticLoggerFixture_TestCase_Must.cs
@@ -15,7 +15,7 @@ namespace KiBoards.Extensions.Logging.Tests
         {
             var provider = new ServiceCollection()
                 .AddDiagnosticLogger(diagnosticLoggerFixture, outputHelper, (config) => config.SetMinimumLevel(LogLevel.Debug))
-                .AddKiBoardsLogging()
+                .AddKiBoardsLogging(outputHelper)
                 .BuildServiceProvider();
 
             _logger = provider.GetRequiredService<ILogger<DiagnosticLoggerFixture_TestCase_Must>>();
@@ -44,11 +44,8 @@ namespace KiBoards.Extensions.Logging.Tests
             {
                 ["ComputerName"] = Environment.MachineName,
             }))
-            {
-                using (_logger.TestScope(_output))
-                {
-                    _logger.LogInformation("Computer Name with Test Run Id");
-                }
+            {              
+               _logger.LogInformation("Computer Name with Test Run Id");               
             }
         }
 

--- a/src/KiBoards.Extensions.Logging/KiBoardsLoggingExtensions.cs
+++ b/src/KiBoards.Extensions.Logging/KiBoardsLoggingExtensions.cs
@@ -8,20 +8,11 @@ namespace KiBoards.Extensions.Logging
 {
     public static class KiBoardsLoggingExtensions
     {
-        public static IDisposable TestScope<T>(this ILogger<T> logger, ITestOutputHelper output)
+     
+        public static IServiceCollection AddKiBoardsLogging(this IServiceCollection services, ITestOutputHelper testOutputHelper, Func<ILoggingBuilder, ILoggingBuilder> configure)
         {
-            var testCase = output.GetTestCase();
+            var testCase = testOutputHelper.GetTestCase();
 
-            return logger.BeginScope(new Dictionary<string, object>()
-            {
-                ["TestCaseId"] = (KiBoardsTestRun.Instance.Id + testCase.UniqueID).ComputeMD5(),
-                ["TestRunId"] = KiBoardsTestRun.Instance.Id,
-                ["TestCaseUniqueId"] = testCase.UniqueID
-            });
-        }
-
-        public static IServiceCollection AddKiBoardsLogging(this IServiceCollection services, Func<ILoggingBuilder, ILoggingBuilder> configure)
-        {
             var elasticOptions = new ElasticsearchSinkOptions(new Uri(Environment.GetEnvironmentVariable("KIB_ELASTICSEARCH_HOST") ?? "http://localhost:9200"))
             {
                 IndexFormat = $"kiboards-testlogs-{DateTime.UtcNow:yyyy-MM}",
@@ -30,11 +21,13 @@ namespace KiBoards.Extensions.Logging
 
             return services.AddLogging(builder => configure(builder).AddSerilog(new LoggerConfiguration()
                 .WriteTo.Elasticsearch(elasticOptions)
+                .Enrich.WithProperty("TestCaseId", (KiBoardsTestRun.Instance.Id + testCase.UniqueID).ComputeMD5())
+                .Enrich.WithProperty("TestRunId", KiBoardsTestRun.Instance.Id)
+                .Enrich.WithProperty("TestCaseUniqueId", testCase.UniqueID)
                 .CreateLogger(), true));
         }
 
-        public static IServiceCollection AddKiBoardsLogging(this IServiceCollection services) => AddKiBoardsLogging(services, (config) => config);
-        public static IServiceCollection AddKiBoardsLogging(this IServiceCollection services, LogLevel minimumLogLevel) => AddKiBoardsLogging(services, (config) => config.SetMinimumLevel(minimumLogLevel));
-       
+        public static IServiceCollection AddKiBoardsLogging(this IServiceCollection services, ITestOutputHelper testOutputHelper) => AddKiBoardsLogging(services, testOutputHelper, (config) => config);
+        public static IServiceCollection AddKiBoardsLogging(this IServiceCollection services, ITestOutputHelper testOutputHelper, LogLevel minimumLogLevel) => AddKiBoardsLogging(services, testOutputHelper, (config) => config.SetMinimumLevel(minimumLogLevel));       
     }
 }


### PR DESCRIPTION
Logger scopes will not work well with other service creating their own loggers. This pushes the logging creation to the test case level.